### PR TITLE
Refactor worker tasks and improve dataset pipeline

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,26 +1,54 @@
-import os, time, signal
-from threading import Event
-from pymongo import MongoClient, ReturnDocument
-from dotenv import load_dotenv
+"""Application entry-point and worker orchestration."""
 
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from threading import Event
+
+from dotenv import load_dotenv
+from pymongo import MongoClient, ReturnDocument
+
+from src.models.worker import Worker
 from src.tasks.builder import run_task as run_builder
 from src.tasks.trainer import run_task as run_trainer
 
 load_dotenv()
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(threadName)s] %(levelname)s: %(message)s",
+)
+
 MONGO_URI = os.getenv("MONGO_URI")
+if not MONGO_URI:
+    raise RuntimeError("MONGO_URI must be defined in the environment")
+
 MAX_WORKERS_BUILDER = int(os.getenv("MAX_WORKERS_BUILDER", "5"))
 MAX_WORKERS_TRAINER = int(os.getenv("MAX_WORKERS_TRAINER", "2"))
 POLL_DELAY = float(os.getenv("POLL_DELAY", "2"))
 
-db = MongoClient(MONGO_URI).get_database()
+client = MongoClient(MONGO_URI)
+db = client.get_database()
 
 stop_event = Event()
-def _stop(*_): stop_event.set()
+
+
+def _stop(*_: object) -> None:
+    """Signal handler that requests a graceful shutdown."""
+
+    stop_event.set()
+
+
 signal.signal(signal.SIGTERM, _stop)
 signal.signal(signal.SIGINT, _stop)
 
+
 def claim_one_status(status: str, new_status: str):
+    """Atomically claim a dataset with the given status and update it."""
+
     return db.get_collection("datasets").find_one_and_update(
         {"status": status},
         {"$set": {"status": new_status}},
@@ -28,12 +56,10 @@ def claim_one_status(status: str, new_status: str):
         return_document=ReturnDocument.AFTER,
     )
 
-import logging
-from src.models.worker import Worker
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(threadName)s] %(levelname)s: %(message)s")
+def main() -> None:
+    """Start background workers and keep the process alive."""
 
-def main():
     logging.info("Lancement des workers…")
 
     workers = [
@@ -58,11 +84,12 @@ def main():
     ]
 
     try:
-        while True:
+        while not stop_event.is_set():
             time.sleep(1)
     except KeyboardInterrupt:
         logging.info("Signal reçu, arrêt en cours…")
+    finally:
         stop_event.set()
-        for w in workers:
-            w.join()
+        for worker in workers:
+            worker.join()
         logging.info("Arrêt terminé.")

--- a/src/helpers/callbacks.py
+++ b/src/helpers/callbacks.py
@@ -1,32 +1,53 @@
+"""Callbacks utilities used during model fine-tuning."""
+
+from __future__ import annotations
+
 import time
 from datetime import datetime
+from typing import Any, Dict, Optional
+
 from bson import ObjectId
 from pymongo import MongoClient
 from transformers import TrainerCallback
 
+
 class MongoTrainLogger(TrainerCallback):
-    def __init__(self, mongo_uri: str, dataset: str, job_coll="datasets", *, model: str, version: str):
+    """Push training metrics to MongoDB in real time."""
+
+    def __init__(
+        self,
+        mongo_uri: str,
+        dataset: str,
+        job_coll: str = "datasets",
+        *,
+        model: str,
+        version: str,
+    ) -> None:
+        if not mongo_uri:
+            raise ValueError("mongo_uri must be provided to MongoTrainLogger")
+
         self.client = MongoClient(mongo_uri)
-        self.db = self.client.get_database()
-        self.col_jobs = self.db[job_coll]
-        self.dataset = dataset
+        self.collection = self.client.get_database()[job_coll]
+        self.dataset_id = ObjectId(str(dataset))
         self.model = model
         self.version = version
         self.t0 = time.time()
         self.last_t = self.t0
         self.last_step = 0
 
-    def on_log(self, args, state, control, logs=None, **kwargs):
+    def _extract_numeric_metrics(self, logs: Optional[Dict[str, Any]]) -> Dict[str, float]:
+        return {
+            key: float(value)
+            for key, value in (logs or {}).items()
+            if isinstance(value, (int, float))
+        }
+
+    def on_log(self, args, state, control, logs=None, **kwargs):  # type: ignore[override]
         now = time.time()
         step = state.global_step or 0
         dstep = step - self.last_step
         dt = max(1e-9, now - self.last_t)
         it_per_s = dstep / dt
-
-        metrics = {}
-        for k, v in (logs or {}).items():
-            if isinstance(v, (int, float)):
-                metrics[k] = float(v)
 
         payload = {
             "ts": datetime.utcnow(),
@@ -34,24 +55,32 @@ class MongoTrainLogger(TrainerCallback):
             "epoch": float(state.epoch or 0),
             "it_per_s": it_per_s,
             "seconds_from_start": now - self.t0,
-            **metrics,
+            **self._extract_numeric_metrics(logs),
         }
 
         progress = None
         if state.max_steps and state.max_steps > 0:
             progress = step / state.max_steps
-        self.col_jobs.update_one(
-            {"_id": ObjectId(self.dataset)},
+
+        self.collection.update_one(
+            {"_id": self.dataset_id},
             {"$set": {"progress": progress, "last_log": payload}},
         )
 
         self.last_t = now
         self.last_step = step
 
-    def on_train_end(self, args, state, control, **kwargs):
-        self.col_jobs.update_one(
-            {"_id": ObjectId(self.dataset)},
-            {"$set": {
-                "finished_at": datetime.utcnow(),
-            }}
+    def on_train_end(self, args, state, control, **kwargs):  # type: ignore[override]
+        self.collection.update_one(
+            {"_id": self.dataset_id},
+            {"$set": {"finished_at": datetime.utcnow()}},
         )
+
+    def close(self) -> None:
+        self.client.close()
+
+    def __del__(self) -> None:  # pragma: no cover - best-effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/helpers/trainer.py
+++ b/src/helpers/trainer.py
@@ -1,139 +1,266 @@
-from datasets import Dataset
-import torch
+"""Training utilities for sequence tagging models."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
 import evaluate
 import numpy as np
+import torch
+from datasets import Dataset
 from transformers import (
-    CamembertTokenizerFast,
     CamembertForTokenClassification,
-    TrainingArguments,
-    Trainer,
+    CamembertTokenizerFast,
     DataCollatorForTokenClassification,
+    Trainer,
+    TrainingArguments,
 )
-from src.helpers.callbacks import MongoTrainLogger
-import os
 
-def prepare_dataset(examples, label_names):
-    tok = CamembertTokenizerFast.from_pretrained("camembert-base")
-    if "O" not in label_names:
-        label_names = ["O"] + list(label_names)
-    others = sorted([l for l in label_names if l != "O"])
-    label_names = ["O"] + others
+from src.helpers.callbacks import MongoTrainLogger
+
+LOGGER = logging.getLogger(__name__)
+MODEL_NAME = "camembert-base"
+MAX_SEQ_LENGTH = 512
+
+
+def _normalise_labels(label_names: Sequence[str]) -> List[str]:
+    unique = []
+    seen = set()
+    for label in label_names:
+        if label not in seen:
+            unique.append(label)
+            seen.add(label)
+
+    if "O" not in seen:
+        unique.insert(0, "O")
+        seen.add("O")
+
+    others = sorted(label for label in unique if label != "O")
+    return ["O", *others]
+
+
+def _ensure_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ensure_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ensure_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if value is None:
+        return default
+    return bool(value)
+
+
+def prepare_dataset(
+    examples: Sequence[Mapping[str, Any]],
+    label_names: Sequence[str],
+    tokenizer: CamembertTokenizerFast,
+) -> Tuple[Dataset, Dict[str, int], Dict[int, str]]:
+    label_names = _normalise_labels(label_names)
     label2id = {name: i for i, name in enumerate(label_names)}
     id2label = {i: name for name, i in label2id.items()}
 
-    records = []
-    for ex in examples:
-        data = ex.get("data", {})
+    records: List[MutableMapping[str, Any]] = []
+    for example in examples:
+        data = example.get("data") or {}
         text = (data.get("text") or "").strip()
         if not text:
             continue
-        ents = data.get("entities", [])
 
-        enc = tok(text, return_offsets_mapping=True, truncation=True, max_length=512)
-        offsets = enc["offset_mapping"]
+        enc = tokenizer(
+            text,
+            return_offsets_mapping=True,
+            truncation=True,
+            max_length=MAX_SEQ_LENGTH,
+        )
+        offsets = enc.pop("offset_mapping")
 
-        y = [label2id["O"]] * len(enc["input_ids"])
-        for i, (s, e) in enumerate(offsets):
-            if s == e == 0:
-                y[i] = -100
+        labels = [label2id["O"]] * len(enc["input_ids"])
+        for i, (start, end) in enumerate(offsets):
+            if start == end == 0:
+                labels[i] = -100
 
-        for start, end, lab in ents:
-            if not isinstance(start, int) or not isinstance(end, int) or end <= start:
+        entities = data.get("entities") or []
+        for start, end, label in entities:
+            if (
+                not isinstance(start, int)
+                or not isinstance(end, int)
+                or end <= start
+            ):
                 continue
             saw_begin = False
-            for i, (s, e) in enumerate(offsets):
-                if s == e == 0:
+            for idx, (tok_start, tok_end) in enumerate(offsets):
+                if tok_start == tok_end == 0:
                     continue
-                if e <= start or s >= end:
+                if tok_end <= start or tok_start >= end:
                     continue
-                tag = f"B-{lab}" if not saw_begin and (s <= start < e) else f"I-{lab}"
+                tag = (
+                    f"B-{label}"
+                    if not saw_begin and (tok_start <= start < tok_end)
+                    else f"I-{label}"
+                )
                 if tag in label2id:
-                    y[i] = label2id[tag]
+                    labels[idx] = label2id[tag]
                     saw_begin = True
 
-        if all(v == -100 for v in y):
+        if all(label == -100 for label in labels):
             continue
 
-        enc.pop("offset_mapping")
-        enc["labels"] = [int(v) for v in y]
+        enc["labels"] = [int(value) for value in labels]
         records.append(enc)
 
     if not records:
         raise ValueError("Dataset vide après parsing")
-    ds = Dataset.from_list(records)
-    return ds, label2id, id2label
 
-def compute_metrics(eval_pred, id2label):
-    preds, labels = eval_pred
-    preds = np.argmax(preds, axis=-1)
-    true_preds, true_labels = [], []
-    for p_seq, l_seq in zip(preds, labels):
-        p_out, l_out = [], []
-        for p, l in zip(p_seq, l_seq):
-            if l == -100:
+    return Dataset.from_list(records), label2id, id2label
+
+
+def compute_metrics(eval_pred: Tuple[np.ndarray, np.ndarray], id2label: Dict[int, str]):
+    logits, labels = eval_pred
+    predictions = np.argmax(logits, axis=-1)
+
+    true_preds: List[List[str]] = []
+    true_labels: List[List[str]] = []
+    for pred_seq, label_seq in zip(predictions, labels):
+        seq_preds: List[str] = []
+        seq_labels: List[str] = []
+        for pred, label in zip(pred_seq, label_seq):
+            if label == -100:
                 continue
-            p_out.append(id2label[p])
-            l_out.append(id2label[l])
-        true_preds.append(p_out)
-        true_labels.append(l_out)
+            seq_preds.append(id2label[int(pred)])
+            seq_labels.append(id2label[int(label)])
+        true_preds.append(seq_preds)
+        true_labels.append(seq_labels)
+
     metric = evaluate.load("seqeval")
     return metric.compute(predictions=true_preds, references=true_labels)
 
-def trainer(dataset, model, *, parameters=None, eval_dataset=None, version=None):
+
+def _collect_label_stats(dataset: Dataset) -> Counter:
+    counter = Counter()
+    sample_size = min(50, len(dataset))
+    if sample_size:
+        for record in dataset.select(range(sample_size)):
+            counter.update(record["labels"])
+    return counter
+
+
+def trainer(
+    dataset: Sequence[Mapping[str, Any]],
+    model: Mapping[str, Any],
+    *,
+    parameters: Optional[Mapping[str, Any]] = None,
+    eval_dataset: Optional[Dataset] = None,
+    version: Optional[str] = None,
+) -> Trainer:
+    if not dataset:
+        raise ValueError("Dataset vide: aucune donnée à entraîner")
+
     parameters = parameters or {}
-    label_names = model.get("labels", [])
-    mref = model.get("reference", "model")
-    mversion = version or model.get("version", "1.0")
-    train_ds, label2id, id2label = prepare_dataset(dataset, label_names)
+    label_names = model.get("labels") or []
+    model_reference = model.get("reference", "model")
+    resolved_version = version or model.get("version", "1.0")
+
+    tokenizer = CamembertTokenizerFast.from_pretrained(MODEL_NAME)
+    train_ds, label2id, id2label = prepare_dataset(dataset, label_names, tokenizer)
+
+    LOGGER.info(
+        "Dataset prêt: %s exemples, %s étiquettes",
+        len(train_ds),
+        len(label2id),
+    )
+
     ner_model = CamembertForTokenClassification.from_pretrained(
-        "camembert-base",
+        MODEL_NAME,
         num_labels=len(label2id),
         id2label=id2label,
         label2id=label2id,
     )
-    tok = CamembertTokenizerFast.from_pretrained("camembert-base")
-    collator = DataCollatorForTokenClassification(tok)
-    use_fp16 = bool(parameters.get("fp16", False)) and torch.cuda.is_available()
-    if parameters.get("fp16", False) and not torch.cuda.is_available():
-        print("[trainer] fp16 demandé mais CUDA indisponible -> on désactive.", flush=True)
-    out_dir = f"./../sardine.agents/{mref}/{mversion}"
+
+    collator = DataCollatorForTokenClassification(tokenizer)
+
+    use_fp16 = _ensure_bool(parameters.get("fp16", False)) and torch.cuda.is_available()
+    if parameters.get("fp16") and not torch.cuda.is_available():
+        LOGGER.warning("fp16 demandé mais CUDA indisponible -> désactivation")
+
+    output_dir = Path("sardine.agents") / model_reference / resolved_version
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logging_dir = Path("logs") / model_reference / resolved_version
+    logging_dir.mkdir(parents=True, exist_ok=True)
+
     args = TrainingArguments(
-        output_dir=out_dir,
-        learning_rate=parameters.get("learning_rate", 5e-5),
-        per_device_train_batch_size=parameters.get("batch_size", 16),
-        num_train_epochs=parameters.get("epochs", 5),
-        weight_decay=parameters.get("weight_decay", 0.01),
+        output_dir=str(output_dir),
+        learning_rate=_ensure_float(parameters.get("learning_rate"), 5e-5),
+        per_device_train_batch_size=_ensure_int(parameters.get("batch_size"), 16),
+        num_train_epochs=_ensure_float(parameters.get("epochs"), 5),
+        weight_decay=_ensure_float(parameters.get("weight_decay"), 0.01),
         save_strategy="epoch",
-        evaluation_strategy=("no" if eval_dataset is None else parameters.get("eval_strategy", "epoch")),
-        logging_dir=f"./logs/{mref}/{mversion}",
-        logging_steps=10,
+        evaluation_strategy=(
+            "no"
+            if eval_dataset is None
+            else str(parameters.get("eval_strategy", "epoch"))
+        ),
+        logging_dir=str(logging_dir),
+        logging_steps=_ensure_int(parameters.get("logging_steps", 10), 10),
         fp16=use_fp16,
-        gradient_accumulation_steps=parameters.get("grad_accum", 1),
+        gradient_accumulation_steps=_ensure_int(parameters.get("grad_accum"), 1),
         group_by_length=True,
-        dataloader_pin_memory=False
+        dataloader_pin_memory=False,
     )
 
-    from collections import Counter
-    c = Counter()
-    for r in train_ds.select(range(min(50, len(train_ds)))):
-        c.update(r["labels"])
-    kept = sum(v for k, v in c.items() if k != -100)
-    print(f"[trainer] first50 label counts={dict(c)} | kept_tokens={kept}", flush=True)
+    label_stats = _collect_label_stats(train_ds)
+    kept = sum(value for key, value in label_stats.items() if key != -100)
+    LOGGER.info("Premiers comptes d'étiquettes (50 échantillons): %s", dict(label_stats))
+    LOGGER.info("Tokens conservés: %s", kept)
 
-    tr = Trainer(
+    trainer_instance = Trainer(
         model=ner_model,
         args=args,
         train_dataset=train_ds,
-        eval_dataset=None if eval_dataset is None else eval_dataset,
-        tokenizer=tok,
+        eval_dataset=eval_dataset,
+        tokenizer=tokenizer,
         data_collator=collator,
-        compute_metrics=(None if eval_dataset is None else (lambda p: compute_metrics(p, id2label))),
+        compute_metrics=(
+            None
+            if eval_dataset is None
+            else (lambda predictions: compute_metrics(predictions, id2label))
+        ),
     )
 
     mongo_uri = os.getenv("MONGO_URI")
-    did = dataset[0].get("dataset")
-    tr.add_callback(MongoTrainLogger(mongo_uri=mongo_uri, dataset=did, model=model, version=mversion))
+    dataset_id = dataset[0].get("dataset") if dataset else None
+    callback: Optional[MongoTrainLogger] = None
+    if mongo_uri and dataset_id:
+        callback = MongoTrainLogger(
+            mongo_uri=mongo_uri,
+            dataset=str(dataset_id),
+            model=model.get("name", model_reference),
+            version=resolved_version,
+        )
+        trainer_instance.add_callback(callback)
 
-    tr.train()
-    tr.save_model(out_dir)
-    tok.save_pretrained(out_dir)
+    trainer_instance.train()
+    trainer_instance.save_model(str(output_dir))
+    tokenizer.save_pretrained(str(output_dir))
+
+    if callback is not None:
+        callback.close()
+
+    return trainer_instance

--- a/src/models/worker.py
+++ b/src/models/worker.py
@@ -1,9 +1,33 @@
-import threading
+"""Worker thread utilities."""
+
+from __future__ import annotations
+
 import logging
-from concurrent.futures import ThreadPoolExecutor
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Callable, Optional
+
+TaskClaimFn = Callable[[], Optional[dict]]
+TaskRunFn = Callable[..., Any]
+
 
 class Worker:
-    def __init__(self, name, claim_fn, run_fn, max_workers, poll_delay, stop_event: threading.Event, *, db):
+    """Manage a pool of worker threads dedicated to a specific task type."""
+
+    def __init__(
+        self,
+        name: str,
+        claim_fn: TaskClaimFn,
+        run_fn: TaskRunFn,
+        max_workers: int,
+        poll_delay: float,
+        stop_event: threading.Event,
+        *,
+        db: Any,
+    ) -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be a positive integer")
+
         self.name = name
         self.claim_fn = claim_fn
         self.run_fn = run_fn
@@ -11,17 +35,18 @@ class Worker:
         self.poll_delay = poll_delay
         self.db = db
         self.stop_event = stop_event
-        self._thread = None
+        self._thread: Optional[threading.Thread] = None
+        self._logger = logging.getLogger(f"worker.{name}")
 
-    def _loop(self):
-        logging.info(f"{self.name}: démarrage (threads={self.max_workers})")
-        futures = set()
-        with ThreadPoolExecutor(max_workers=self.max_workers, thread_name_prefix=self.name) as executor:
+    def _loop(self) -> None:
+        self._logger.info("démarrage (threads=%s)", self.max_workers)
+        futures: set[Future[Any]] = set()
+        with ThreadPoolExecutor(
+            max_workers=self.max_workers, thread_name_prefix=self.name
+        ) as executor:
             while not self.stop_event.is_set():
-                # Nettoyage des futures terminées
-                futures = {f for f in futures if not f.done()}
+                futures = {future for future in futures if not future.done()}
 
-                # Remplir le pool
                 made_progress = False
                 while not self.stop_event.is_set() and len(futures) < self.max_workers:
                     task = self.claim_fn()
@@ -30,25 +55,30 @@ class Worker:
                     futures.add(executor.submit(self._run_one, task))
                     made_progress = True
 
-                # Eviter le busy-wait : attendre avec timeout
                 if not made_progress:
-                    # si pas de tâche dispo -> attendre poll_delay, sinon on est à capacité -> petite attente
-                    timeout = self.poll_delay if len(futures) < self.max_workers else 0.2
+                    timeout = (
+                        self.poll_delay
+                        if len(futures) < self.max_workers
+                        else 0.2
+                    )
                     self.stop_event.wait(timeout)
 
-        logging.info(f"{self.name}: arrêt propre")
+        self._logger.info("arrêt propre")
 
-    def _run_one(self, task):
+    def _run_one(self, task: dict) -> None:
         try:
-            return self.run_fn(doc=task, db=self.db, MAX_WORKERS=self.max_workers)
-        except Exception as e:
-            logging.exception(f"{self.name}: échec de la tâche {task}: {e}")
+            self.run_fn(doc=task, db=self.db, MAX_WORKERS=self.max_workers)
+        except Exception:  # pragma: no cover - defensive logging
+            self._logger.exception("échec de la tâche %s", task)
 
-    def start(self):
-        self._thread = threading.Thread(target=self._loop, name=f"mgr-{self.name}", daemon=True)
+    def start(self) -> "Worker":
+        self._thread = threading.Thread(
+            target=self._loop, name=f"mgr-{self.name}", daemon=True
+        )
         self._thread.start()
         return self
 
-    def join(self):
+    def join(self) -> None:
         if self._thread is not None:
             self._thread.join()
+            self._thread = None

--- a/src/tasks/builder.py
+++ b/src/tasks/builder.py
@@ -1,85 +1,114 @@
-from bson import ObjectId
+"""Dataset generation task."""
+
+from __future__ import annotations
+
+import logging
+import random
+import re
+from collections.abc import Iterable, Mapping
 from datetime import datetime
-from typing import Literal, Optional
-import os, time, random, re, copy, rstr
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-context_db = None
+import rstr
+from bson import ObjectId
 
-def run_task(*, doc: dict= None, db=None, MAX_WORKERS=2) -> dict:
-    if doc is None: return 
-    
-    global context_db
-    context_db = db
-    
-    col_tasks = db.get_collection("datasets")
-    col_data = db.get_collection("datasets_data")
-    col_models = db.get_collection("models")
-    col_configs = db.get_collection("models_configurations")
+LOGGER = logging.getLogger(__name__)
+PLACEHOLDER_PATTERN = re.compile(r"\{(?P<key>[^:{}]+)(?::[^{}]*)?\}")
+BULK_INSERT_SIZE = 500
 
-    docdtid = str(doc["_id"])
-    model = col_models.find_one({"_id": ObjectId(doc.get("model"))})
 
-    mversion = model.get("version", "1.0")
-    ments = model.get("entities", {})
-    mkeys = list(ments.keys())
+def run_task(*, doc: Optional[Mapping[str, Any]] = None, db=None, MAX_WORKERS: int = 2) -> None:
+    if not doc or db is None:
+        LOGGER.warning("builder: tâche ignorée (doc ou db manquant)")
+        return
 
-    mcid = model.get("configuration", None)
-    if not mcid:
+    datasets = db.get_collection("datasets")
+    data_collection = db.get_collection("datasets_data")
+    models = db.get_collection("models")
+    configs = db.get_collection("models_configurations")
+
+    dataset_id = doc["_id"]
+    if not isinstance(dataset_id, ObjectId):
+        dataset_id = ObjectId(dataset_id)
+
+    model_id = doc.get("model")
+    if not model_id:
         raise ValueError("Model configuration is missing")
 
-    configuration = col_configs.find_one({"_id": ObjectId(mcid)})
+    if not isinstance(model_id, ObjectId):
+        model_id = ObjectId(model_id)
 
-    dataset = []
+    model = models.find_one({"_id": model_id})
+    if not model:
+        raise ValueError(f"Model introuvable: {model_id}")
 
-    size = doc.get("size", "recommended")
-    n_max = configuration.get("possibilities", 1e5)
-    n_size = size.get("size", n_max)
-    if is_integer(n_size):
-        n_size = int(n_size)
+    configuration_id = model.get("configuration")
+    if not configuration_id:
+        raise ValueError("Model configuration is missing")
+
+    if not isinstance(configuration_id, ObjectId):
+        configuration_id = ObjectId(configuration_id)
+
+    configuration = configs.find_one({"_id": configuration_id})
+    if not configuration:
+        raise ValueError(f"Configuration introuvable: {configuration_id}")
+
+    entity_keys = list((model.get("entities") or {}).keys())
+    randomizers = model.get("randomizers") or []
+    builder = DatasetBuilder(configuration=configuration, db=db, entity_keys=entity_keys, randomizers=randomizers)
+
+    size_info = doc.get("size", {})
+    max_possibilities = int(configuration.get("possibilities", 1e5))
+    formats_count = len(configuration.get("formats") or [])
+    dataset_size = determine_dataset_size(size_info, max_possibilities, formats_count)
+
+    LOGGER.info("builder[%s]: génération de %s entrées", dataset_id, dataset_size)
+    datasets.update_one(
+        {"_id": dataset_id},
+        {"$set": {"status": "generating", "progress": 0.0}},
+    )
+
+    samples: List[Dict[str, Any]] = []
+    update_interval = max(1, dataset_size // 100)
+    for index in range(dataset_size):
+        samples.append(builder.generate_sample())
+        if (index + 1) % update_interval == 0 or index + 1 == dataset_size:
+            progress = (index + 1) / dataset_size
+            datasets.update_one({"_id": dataset_id}, {"$set": {"progress": progress}})
+
+    payloads = [
+        {"dataset": dataset_id, "data": sample, "created_at": datetime.utcnow()}
+        for sample in samples
+    ]
+
+    for start in range(0, len(payloads), BULK_INSERT_SIZE):
+        chunk = payloads[start : start + BULK_INSERT_SIZE]
+        if chunk:
+            data_collection.insert_many(chunk)
+
+    datasets.update_one(
+        {"_id": dataset_id},
+        {"$set": {"status": "generated", "progress": 0.0}},
+    )
+
+
+def determine_dataset_size(size_info: Any, max_size: int, formats_count: int) -> int:
+    formats_count = max(1, formats_count)
+    if isinstance(size_info, Mapping):
+        requested = size_info.get("size", max_size)
     else:
-        n_size = model_build_calculate_size(n_size, n_max, len(configuration.get("formats", [])))
+        requested = size_info or max_size
 
-    progress = 0
-    col_tasks.update_one({"_id": ObjectId(docdtid)}, {"$set": {"status": "generating", "progress": progress}})
+    if is_integer(requested):
+        value = max(1, int(requested))
+        return min(value, max_size)
 
-    for _ in range(int(n_size)):
-        mvb = build_model_configuration(copy.deepcopy(configuration))
+    keyword = str(requested).lower()
+    return calculate_size_from_keyword(keyword, max_size, formats_count)
 
-        try:
-            mrd = random.choice(model.get("randomizers", []))
-            rdm = build_model_configuration_randomizers(mrd)
-            mvb["format"] = rdm(mvb["format"])
-        except: pass
-        
-        dataset.append(
-            build_model_entity(
-                mvb,
-                mkeys
-            )
-        )
 
-        time.sleep(1e-9)
-
-        n_progress = float((len(dataset) / n_size))
-        if n_progress > progress:
-            progress = n_progress
-            col_tasks.update_one({"_id": ObjectId(docdtid)}, {"$set": {"progress": progress}})
-
-    for data in dataset:
-        col_data.insert_one({
-            "dataset": ObjectId(docdtid),
-            "data": data,
-            "created_at": datetime.utcnow(),
-        })
-
-    col_tasks.update_one({"_id": ObjectId(docdtid)}, {"$set": {"status": "generated", "progress": 0.0}})
-
-def model_build_calculate_size(
-        size: str,
-        max_size: int,
-        formats_size: int
-    ) -> int:
-    match size:
+def calculate_size_from_keyword(keyword: str, max_size: int, formats_size: int) -> int:
+    match keyword:
         case "complete":
             return max_size
         case "advanced":
@@ -89,277 +118,242 @@ def model_build_calculate_size(
         case "small":
             return max_size // formats_size // 2
         case "tiny":
-            return max_size // formats_size // 5
+            return max(max_size // formats_size // 5, 1)
         case _:
-            return int(1e3)
+            return min(max_size, 1000)
 
-def build_model_configuration(
-        configuration: dict
-    ) -> dict:
-    catt = configuration.get("attributes")
-    cfmt = configuration.get("formats")
 
-    sfmt = random.choice(cfmt)
-    satt = []
+class DatasetBuilder:
+    def __init__(
+        self,
+        *,
+        configuration: Mapping[str, Any],
+        db,
+        entity_keys: Sequence[str],
+        randomizers: Sequence[Mapping[str, Any]],
+    ) -> None:
+        self.configuration = configuration
+        self.db = db
+        self.entity_keys = list(entity_keys)
+        self.randomizers = list(randomizers)
 
-    for attr in catt:
-        kattr = attr.get("key")
-        fattr = float(attr.get("frequency", 1))
-        rattr = attr.get("requirements", [])
-        vattr = attr.get("value") if fattr > random.random() else False
+    def generate_sample(self) -> Dict[str, Any]:
+        built_config = self._build_configuration(self.configuration)
+        template = built_config["template"]
+        attributes = built_config["attributes"]
+        resolved_text, entities = self._render_entity(template, attributes)
+        resolved_text = self._apply_randomizer(resolved_text)
+        return {"text": resolved_text.strip(), "entities": entities}
 
-        if isinstance(vattr, dict):
-            tvattr = vattr.get("type")
-            rvattr = vattr.get("rule")
-            pvattr = vattr.get("parameters", {})
-            bvattr, bcattrs = build_model_configuration_value(tvattr, rvattr, pvattr)
+    def _build_configuration(self, configuration: Mapping[str, Any]) -> Dict[str, Any]:
+        template = random.choice(configuration.get("formats") or [""])
+        attributes = configuration.get("attributes") or []
+        built_attributes: List[Dict[str, Any]] = []
 
-            if bcattrs:
-                for bcattr in bcattrs:
-                    satt.append(bcattr)
-        
-        satt.append({
-            "key": kattr,
-            "value": bvattr if vattr else '',
-            "requirements": build_model_configuration_requirements(bvattr, rattr) if vattr else True
-        })
+        for attribute in attributes:
+            built_attr, extra_attrs = self._build_attribute(attribute)
+            built_attributes.append(built_attr)
+            built_attributes.extend(extra_attrs)
 
-    bfmt = build_model_configuration_format(sfmt, satt)
-    configuration['attributes'] = satt
-    configuration['format'] = re.sub(r'\s+', ' ', bfmt.strip())
+        return {"template": re.sub(r"\s+", " ", template.strip()), "attributes": built_attributes}
 
-    return configuration
+    def _build_attribute(self, attribute: Mapping[str, Any]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+        key = attribute.get("key")
+        frequency = float(attribute.get("frequency", 1))
+        include = random.random() <= frequency
+        requirements = attribute.get("requirements") or []
 
-def build_model_configuration_value(
-    vtype: Literal["number", "string"],
-    rule: str,
-    parameters: dict
-) -> Optional[int | str]:
-    value = None
+        value_spec = attribute.get("value") if include else None
+        extra_attrs: List[Dict[str, Any]] = []
+        value: Any = ""
 
-    match rule:
-        case "randint":
-            vmin = int(parameters.get("min", 0))
-            vmax = int(parameters.get("max", 100))
-            if vmin > vmax: vmin, vmax = vmax, vmin
-            value = random.randint(vmin, vmax)
+        if isinstance(value_spec, Mapping):
+            value, extra_attrs = self._build_dynamic_value(value_spec)
+        elif value_spec is not None:
+            value = value_spec
 
-        case "alphanum":
-            regex = parameters.get("regex", "")
-            value = rstr.xeger(regex)
+        requirement_ok = True
+        if include and value not in (None, ""):
+            requirement_ok = self._check_requirements(value, requirements)
+            if not requirement_ok:
+                value = ""
 
-        case "data":
-            data_id = parameters.get("object_id")
-            if data_id:
-                data = context_db.get_collection("models_data").find_one({"_id": ObjectId(data_id)})
-                value = random.choice(data.get("data", []))
+        return (
+            {"key": key, "value": "" if value is None else value, "requirements": requirement_ok},
+            extra_attrs,
+        )
 
-        case "configuration":
-            config_id = parameters.get("object_id")
-            if config_id:
-                config = context_db.get_collection("models_configurations").find_one({"_id": ObjectId(config_id)})
-                value = build_model_configuration(config)
-                return value.get("format", ""), config.get("attributes", [])
-    
-    if value is None: return None, None
-        
-    return build_model_configuration_vtype(vtype, value), None
+    def _build_dynamic_value(self, spec: Mapping[str, Any]) -> Tuple[Any, List[Dict[str, Any]]]:
+        value_type = spec.get("type", "string")
+        rule = spec.get("rule")
+        parameters = spec.get("parameters") or {}
 
-def build_model_configuration_vtype(
-    vtype: Literal["number", "string"],
-    value: any
-) -> Optional[int | str]:
-    match vtype:
-        case "number":
-            try:
-                return int(value)
-            except:
-                return str(value)
-        case _:
-            return str(value)
-
-def build_model_configuration_requirements(
-    value: any,
-    requirements: list[dict]
-) -> bool:
-    for req in requirements:
-        rreq = req.get("rule")
-        creq = req.get("constraint")
-
-        match rreq:
-            case "regex":
-                if not re.match(creq, str(value)):
-                    return False
-            case "eq":
-                if str(value) != str(creq):
-                    return False
-            case "neq":
-                if str(value) == str(creq):
-                    return False
-            case "gt":
-                try:
-                    if float(value) <= float(creq):
-                        return False
-                except: pass
-            case "lt":
-                try:
-                    if float(value) >= float(creq):
-                        return False
-                except: pass
-            case "gte":
-                try:
-                    if float(value) < float(creq):
-                        return False
-                except: pass
-            case "lte":
-                try:
-                    if float(value) > float(creq):
-                        return False
-                except: pass
-            case "in":
-                creq  = [x.strip() for x in creq.split(",")] if isinstance(creq, str) else creq
-                if str(value) not in map(str, creq):
-                    return False
-            case "nin":
-                creq  = [x.strip() for x in creq.split(",")] if isinstance(creq, str) else creq
-                if str(value) in map(str, creq):
-                    return False
-            case "contains":
-                if str(creq) not in str(value):
-                    return False
-            case "ncontains":
-                if str(creq) in str(value):
-                    return False
+        match rule:
+            case "randint":
+                minimum = int(parameters.get("min", 0))
+                maximum = int(parameters.get("max", 100))
+                if minimum > maximum:
+                    minimum, maximum = maximum, minimum
+                value = random.randint(minimum, maximum)
+                return coerce_type(value_type, value), []
+            case "alphanum":
+                regex = parameters.get("regex", "")
+                value = rstr.xeger(regex) if regex else ""
+                return coerce_type(value_type, value), []
+            case "data":
+                data_id = parameters.get("object_id")
+                if data_id:
+                    record = self.db.get_collection("models_data").find_one({"_id": ObjectId(data_id)})
+                    if record and record.get("data"):
+                        value = random.choice(record["data"])
+                        return coerce_type(value_type, value), []
+                return "", []
+            case "configuration":
+                config_id = parameters.get("object_id")
+                if config_id:
+                    nested = self.db.get_collection("models_configurations").find_one({"_id": ObjectId(config_id)})
+                    if nested:
+                        built = self._build_configuration(nested)
+                        return built.get("template", ""), built.get("attributes", [])
+                return "", []
             case _:
-                pass
-                
-    return True
+                return "", []
 
-def build_model_configuration_format(
-    format: str,
-    attributes: list[dict]
-) -> str:
-    for attr in attributes:
-        kattr = attr.get("key")
-        vattr = str(attr.get("value", ""))
-        # format = format.replace(f"{{{kattr}}}", str(vattr))
-        format = format.replace(f"{{{kattr}}}", f"{{{kattr}:{vattr}}}")
-    return format
+    def _check_requirements(self, value: Any, requirements: Iterable[Mapping[str, Any]]) -> bool:
+        for requirement in requirements or []:
+            rule = requirement.get("rule")
+            constraint = requirement.get("constraint")
+            try:
+                if rule == "regex":
+                    if not re.match(str(constraint), str(value)):
+                        return False
+                elif rule == "eq" and str(value) != str(constraint):
+                    return False
+                elif rule == "neq" and str(value) == str(constraint):
+                    return False
+                elif rule == "gt" and float(value) <= float(constraint):
+                    return False
+                elif rule == "lt" and float(value) >= float(constraint):
+                    return False
+                elif rule == "gte" and float(value) < float(constraint):
+                    return False
+                elif rule == "lte" and float(value) > float(constraint):
+                    return False
+                elif rule == "in":
+                    if str(value) not in split_constraint(constraint):
+                        return False
+                elif rule == "nin":
+                    if str(value) in split_constraint(constraint):
+                        return False
+                elif rule == "contains" and str(constraint) not in str(value):
+                    return False
+                elif rule == "ncontains" and str(constraint) in str(value):
+                    return False
+            except Exception:
+                return False
+        return True
 
-def build_model_configuration_randomizers(
-    randomizer:  str
-) -> lambda x: x:
-    rrand = randomizer.get("rule")
-    frand = randomizer.get("frequency", 1)
+    def _render_entity(
+        self,
+        template: str,
+        attributes: Sequence[Mapping[str, Any]],
+    ) -> Tuple[str, List[List[Any]]]:
+        attr_map = {attr.get("key"): attr for attr in attributes}
+        resolved_values: Dict[str, str] = {}
 
-    f = None
+        def resolve_value(key: str, stack: Optional[List[str]] = None) -> str:
+            stack = stack or []
+            if key in resolved_values:
+                return resolved_values[key]
+            if key in stack:
+                return ""
+            attr = attr_map.get(key)
+            if not attr or not attr.get("requirements", True):
+                resolved = ""
+            else:
+                raw_value = str(attr.get("value", ""))
+                parts = []
+                last = 0
+                for match in PLACEHOLDER_PATTERN.finditer(raw_value):
+                    parts.append(raw_value[last : match.start()])
+                    nested_key = match.group("key")
+                    parts.append(resolve_value(nested_key, stack + [key]))
+                    last = match.end()
+                parts.append(raw_value[last:])
+                resolved = "".join(parts)
+            resolved_values[key] = resolved
+            return resolved
 
-    match rrand:
-        case "upper":
-            f = lambda x: x.upper()
-        case "lower":
-            f = lambda x: x.lower()
-        case _:
-            f = lambda x: x
+        parts: List[str] = []
+        entities: List[List[Any]] = []
+        cursor = 0
+        last_index = 0
 
-    return f if frand >= random.random() else lambda x: x
+        for match in PLACEHOLDER_PATTERN.finditer(template):
+            parts.append(template[last_index : match.start()])
+            cursor += len(template[last_index : match.start()])
 
-def get_order_entities(
-    text: str
-) -> list[str]:
-    results = []
-    stack = []
-    key = ''
-    reading_key = False
-    reading_value = False
+            key = match.group("key")
+            value = resolve_value(key)
 
-    for i, ch in enumerate(text):
-        if ch == '{':
-            reading_key = True
-            key = ''
-        elif ch == ':' and reading_key:
-            # fin de clé
-            stack.append(key)
-            reading_key = False
-            reading_value = True
-            key = ''
-        elif ch == '}':
-            if stack:
-                results.append(stack.pop())
-            reading_value = False
-        elif reading_key:
-            key += ch
-        elif ch == '{' or ch == '}':
-            pass
-        else:
-            pass
+            if key in self.entity_keys and value:
+                start = cursor
+                cursor += len(value)
+                entities.append([start, cursor, key])
+            else:
+                cursor += len(value)
 
-    return results
+            parts.append(value)
+            last_index = match.end()
+
+        parts.append(template[last_index:])
+        cursor += len(template[last_index:])
+
+        final_text = "".join(parts)
+        return final_text, entities
+
+    def _apply_randomizer(self, text: str) -> str:
+        if not self.randomizers:
+            return text
+        randomizer = random.choice(self.randomizers)
+        frequency = float(randomizer.get("frequency", 1))
+        if random.random() > frequency:
+            return text
+        rule = randomizer.get("rule")
+        if rule == "upper":
+            return text.upper()
+        if rule == "lower":
+            return text.lower()
+        return text
 
 
-def build_model_entity(
-    configuration: dict,
-    keys: list[str],
-) -> dict:
-    vfmt = configuration.get("format", "")
-    ents = []
+def coerce_type(value_type: str, value: Any) -> Any:
+    if value is None:
+        return None
+    if value_type == "number":
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+    return str(value)
 
-    replaced = []
-    in_replaced = []
 
-    attrs = configuration.get("attributes", [])
-    order = get_order_entities(vfmt)
+def split_constraint(constraint: Any) -> List[str]:
+    if isinstance(constraint, str):
+        return [part.strip() for part in constraint.split(",") if part.strip()]
+    if isinstance(constraint, Iterable):
+        return [str(item) for item in constraint]
+    return [str(constraint)]
 
-    attrs_sorted = sorted(
-        attrs,
-        key=lambda a: order.index(a["key"]) if a.get("key") in order else len(order)
-    )
 
-    for attr in attrs_sorted:
-        kattr = attr.get("key")
-        vattr = str(attr.get("value", ""))
-        rattr = attr.get("requirements", True)
-
-        continue_f = True
-
-        if not kattr in keys or \
-            vattr == '' or not rattr:
-            continue_f = False
-
-        for r in replaced:
-            if r['format'] in vattr:
-                vattr = vattr.replace(r['format'], r['value'])
-                in_replaced.append({"ikey": r["key"], "key": kattr}) 
-
-        strvattr = f"{{{kattr}:{vattr}}}" #
-        # strvattr = str(vattr)
-
-        replaced.append({"format": strvattr, "value": vattr, "key": kattr})
-
-        sta = vfmt.lower().find(strvattr.lower()) if vattr else -1
-        vfmt = vfmt.replace(strvattr, str(vattr)) #
-        if sta == -1 or not continue_f: continue
-        # end = sta + len(strvattr)
-        end = sta + len(vattr) #
-
-        ents.append([sta, end, kattr])
-
-    for ir in in_replaced:
-        for n in range(len(ents)):
-            st, ed, ke = ents[n]
-            if ir["ikey"] == ke:
-                ents[n][0] = st - len(ir["key"]) - 2
-                ents[n][1] = ed - len(ir["key"]) - 2
-
-    return { "text": vfmt.strip(), "entities": ents }
-
-def is_integer(value: any) -> bool:
+def is_integer(value: Any) -> bool:
     try:
         int(value)
         return True
     except (ValueError, TypeError):
         return False
-    
+
+
 def bump_version(version: str, bump: str) -> str:
     major, minor = map(int, version.split("."))
     if bump == "major":

--- a/src/tasks/trainer.py
+++ b/src/tasks/trainer.py
@@ -1,66 +1,120 @@
+"""Training task orchestration."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import traceback
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
 from bson import ObjectId
-import os, traceback
 
 from src.helpers.trainer import trainer as run_trainer
 
-def run_task(*, doc: dict=None, db=None, MAX_WORKERS=2):
-    if doc is None: return 
-    
-    col_tasks = db.get_collection("datasets")
-    col_data = db.get_collection("datasets_data")
-    col_models = db.get_collection("models")
-    col_agents = db.get_collection("agents")
+LOGGER = logging.getLogger(__name__)
 
-    jid = str(doc["_id"])
+
+def run_task(*, doc: Optional[Mapping[str, Any]] = None, db=None, MAX_WORKERS: int = 2) -> None:
+    if not doc or db is None:
+        LOGGER.warning("trainer: tâche ignorée (doc ou db manquant)")
+        return
+
+    datasets = db.get_collection("datasets")
+    data_collection = db.get_collection("datasets_data")
+    models = db.get_collection("models")
+    agents = db.get_collection("agents")
+
+    dataset_id = doc.get("_id")
+    if not dataset_id:
+        raise ValueError("Identifiant de dataset manquant")
+    if not isinstance(dataset_id, ObjectId):
+        dataset_id = ObjectId(dataset_id)
+
+    job_id = str(dataset_id)
+
     try:
-        total = os.cpu_count() or 4
-        per_worker = max(1, total // MAX_WORKERS)
+        total_cpus = os.cpu_count() or 4
+        per_worker = max(1, total_cpus // max(1, MAX_WORKERS))
         os.environ.setdefault("OMP_NUM_THREADS", str(per_worker))
         os.environ.setdefault("MKL_NUM_THREADS", str(per_worker))
 
-        dataset = list(col_data.find({"dataset": ObjectId(doc["_id"])}))
+        dataset = list(data_collection.find({"dataset": dataset_id}))
+        if not dataset:
+            raise ValueError("Dataset vide: impossible d'entraîner le modèle")
+
         model_id = doc.get("model")
         if not model_id:
             raise ValueError("model_id manquant")
-        model = col_models.find_one({"_id": ObjectId(model_id)})
+        if not isinstance(model_id, ObjectId):
+            model_id = ObjectId(model_id)
+
+        model = models.find_one({"_id": model_id})
         if not model:
-            raise ValueError(f"modèle introuvable: {model_id}")
-        
+            raise ValueError(f"Modèle introuvable: {model_id}")
+
         version = doc.get("version", "1.0")
-        params = doc.get("parameters", {})
+        parameters = doc.get("parameters") or {}
 
-        col_tasks.update_one({"_id": doc["_id"]}, {"$set": {"status": "training", "started_at": datetime.utcnow()}})
-        print(f"[{jid}] start training… model={model.get('name')} v={version} | items={len(dataset)}", flush=True)
+        datasets.update_one(
+            {"_id": dataset_id},
+            {"$set": {"status": "training", "started_at": datetime.utcnow()}},
+        )
+        LOGGER.info(
+            "[%s] lancement de l'entraînement du modèle %s (version %s) avec %s exemples",
+            job_id,
+            model.get("name"),
+            version,
+            len(dataset),
+        )
 
-        run_trainer(dataset, model, parameters=params, version=version)
+        run_trainer(dataset, model, parameters=parameters, version=version)
 
-        col_data.delete_many({"dataset": ObjectId(doc["_id"])})
+        data_collection.delete_many({"dataset": dataset_id})
 
-        col_tasks.update_one({"_id": doc["_id"]}, {"$set": {"status": "completed", "finished_at": datetime.utcnow()}})
+        datasets.update_one(
+            {"_id": dataset_id},
+            {"$set": {"status": "completed", "finished_at": datetime.utcnow()}},
+        )
 
-        path = f"sardine.agents/{doc.get('reference')}/{version}"
+        target_path = Path("sardine.agents") / doc.get("reference", "agent") / version
 
-        col_agents.insert_one({
-            "created_by": doc.get("created_by"),
-            "created_at": datetime.utcnow(),
-            "model": ObjectId(model_id),
-            "version": version,
-            "name": doc.get('name'),
-            "reference": doc.get('reference'),
-            "description": doc.get('description'),
-            "path": path,
-            "status": "enabled",
-        })
+        agents.insert_one(
+            {
+                "created_by": doc.get("created_by"),
+                "created_at": datetime.utcnow(),
+                "model": model_id,
+                "version": version,
+                "name": doc.get("name"),
+                "reference": doc.get("reference"),
+                "description": doc.get("description"),
+                "path": str(target_path),
+                "status": "enabled",
+            }
+        )
 
-        for repo in os.listdir(path):
-            if repo.startswith('checkpoint-'):
-                checkpoint_path = os.path.join(path, repo)
-                if os.path.isdir(checkpoint_path):
-                    os.remove(checkpoint_path)
+        cleanup_checkpoints(target_path)
+        LOGGER.info("[%s] entraînement terminé", job_id)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        error_message = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+        datasets.update_one(
+            {"_id": dataset_id},
+            {
+                "$set": {
+                    "status": "failed",
+                    "error": error_message,
+                    "finished_at": datetime.utcnow(),
+                }
+            },
+        )
+        LOGGER.error("[%s] entraînement échoué: %s", job_id, error_message)
 
-        print(f"[{jid}] done ✅", flush=True)
-    except Exception as e:
-        err = "".join(traceback.format_exception_only(type(e), e)).strip()
-        col_tasks.update_one({"_id": doc["_id"]}, {"$set": {"status": "failed", "error": err, "finished_at": datetime.utcnow()}})
-        print(f"[{jid}] failed ❌ {err}", flush=True)
+
+def cleanup_checkpoints(path: Path) -> None:
+    if not path.exists():
+        return
+    for item in path.iterdir():
+        if item.name.startswith("checkpoint-") and item.is_dir():
+            shutil.rmtree(item, ignore_errors=True)


### PR DESCRIPTION
## Summary
- harden worker bootstrap by requiring a Mongo URI and ensuring threads exit cleanly when stopping
- refactor the dataset builder to validate configurations, resolve nested attributes, and batch MongoDB writes
- streamline the training helpers to normalise parameters, manage Mongo callbacks, and clean up saved checkpoints

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d1032c0e14832a948fb003ee8ea18b