### PR TITLE
Fix requirement handling in dataset builder

### DIFF
--- a/src/tasks/builder.py
+++ b/src/tasks/builder.py
@@ -268,7 +268,7 @@ class DatasetBuilder:
             if key in stack:
                 return ""
             attr = attr_map.get(key)
-            if not attr or not attr.get("requirements", True):
+            if not attr:
                 resolved = ""
             else:
                 raw_value = str(attr.get("value", ""))
@@ -295,8 +295,10 @@ class DatasetBuilder:
 
             key = match.group("key")
             value = resolve_value(key)
+            attr = attr_map.get(key)
+            requirements_met = True if attr is None else bool(attr.get("requirements", True))
 
-            if key in self.entity_keys and value:
+            if key in self.entity_keys and value and requirements_met:
                 start = cursor
                 cursor += len(value)
                 entities.append([start, cursor, key])

--- a/src/tasks/builder.py
+++ b/src/tasks/builder.py
@@ -161,7 +161,15 @@ class DatasetBuilder:
         key = attribute.get("key")
         frequency = float(attribute.get("frequency", 1))
         include = random.random() <= frequency
-        requirements = attribute.get("requirements") or []
+        requirement_spec = attribute.get("requirements")
+        if isinstance(requirement_spec, Mapping):
+            requirements = [requirement_spec]
+        elif isinstance(requirement_spec, Iterable) and not isinstance(
+            requirement_spec, (str, bytes)
+        ):
+            requirements = list(requirement_spec)
+        else:
+            requirements = []
 
         value_spec = attribute.get("value") if include else None
         extra_attrs: List[Dict[str, Any]] = []
@@ -172,16 +180,11 @@ class DatasetBuilder:
         elif value_spec is not None:
             value = value_spec
 
-        requirement_ok = True
-        if include and value not in (None, ""):
-            requirement_ok = self._check_requirements(value, requirements)
-            # if not requirement_ok:
-            #     value = ""
+        attribute_payload: Dict[str, Any] = {"key": key, "value": "" if value is None else value}
+        if requirements:
+            attribute_payload["requirements"] = requirements
 
-        return (
-            {"key": key, "value": "" if value is None else value, "requirements": requirement_ok},
-            extra_attrs,
-        )
+        return attribute_payload, extra_attrs
 
     def _build_dynamic_value(self, spec: Mapping[str, Any]) -> Tuple[Any, List[Dict[str, Any]]]:
         value_type = spec.get("type", "string")
@@ -281,6 +284,9 @@ class DatasetBuilder:
                     last = match.end()
                 parts.append(raw_value[last:])
                 resolved = "".join(parts)
+                attr["requirements_met"] = self._check_requirements(
+                    resolved, attr.get("requirements")
+                )
             resolved_values[key] = resolved
             return resolved
 
@@ -296,7 +302,7 @@ class DatasetBuilder:
             key = match.group("key")
             value = resolve_value(key)
             attr = attr_map.get(key)
-            requirements_met = True if attr is None else bool(attr.get("requirements", True))
+            requirements_met = True if attr is None else attr.get("requirements_met", True)
 
             if key in self.entity_keys and value and requirements_met:
                 start = cursor

--- a/src/tasks/trainer.py
+++ b/src/tasks/trainer.py
@@ -91,6 +91,7 @@ def run_task(*, doc: Optional[Mapping[str, Any]] = None, db=None, MAX_WORKERS: i
                 "reference": doc.get("reference"),
                 "description": doc.get("description"),
                 "path": str(target_path),
+                "mapper": model.get("mapper"),
                 "status": "enabled",
             }
         )


### PR DESCRIPTION
## Summary
- ensure attribute values are still resolved even when a requirement check fails
- prevent entity creation when the related attribute requirements are not met

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d24e80a0a4832a90e90049610c020e