### PR TITLE
Refactor training for document extraction agents

### DIFF
--- a/src/helpers/document.py
+++ b/src/helpers/document.py
@@ -1,0 +1,631 @@
+"""Domain-specific helpers for document extraction agents.
+
+This module introduces a structured way to describe document fields, build
+domain vocabularies and map model predictions to JSON data structures. It
+provides building blocks to assemble specialised "agents" that can later be
+combined to cover complete document understanding workflows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from statistics import mean
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+import copy
+import json
+from pathlib import Path
+import re
+
+
+def _normalise_path(path: Sequence[Any] | None, *, fallback: str) -> tuple[str, ...]:
+    values: list[str] = []
+    if path is None:
+        path = ()
+    for part in path:
+        if part is None:
+            continue
+        part_str = str(part).strip()
+        if part_str:
+            values.append(part_str)
+    if not values:
+        fallback_value = fallback.strip()
+        if not fallback_value:
+            raise ValueError("Document paths require at least one segment")
+        values.append(fallback_value)
+    return tuple(values)
+
+
+def _normalise_label(label: str) -> str:
+    stripped = str(label or "").strip()
+    if not stripped:
+        raise ValueError("Labels must be non empty strings")
+    if stripped.upper().startswith(("B-", "I-")):
+        return stripped.split("-", 1)[1]
+    return stripped
+
+
+def _deduplicate_preserve_order(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        lower = value.lower()
+        if lower in seen:
+            continue
+        seen.add(lower)
+        ordered.append(value)
+    return ordered
+
+
+def _empty_payload() -> dict[str, Any]:
+    return {"value": None, "confidence": 0.0, "provenance": None}
+
+
+def _is_payload(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return {"value", "confidence"}.issubset(value.keys())
+
+
+@dataclass(frozen=True)
+class DocumentField:
+    """Describe a scalar piece of information to extract from a document."""
+
+    name: str
+    label: str
+    path: Sequence[str] | None = None
+    description: str = ""
+    required: bool = False
+    multiple: bool = False
+
+    def __post_init__(self) -> None:
+        cleaned_name = str(self.name or "").strip()
+        if not cleaned_name:
+            raise ValueError("Field names must be non empty")
+        object.__setattr__(self, "name", cleaned_name)
+        object.__setattr__(self, "label", _normalise_label(self.label))
+        object.__setattr__(self, "path", _normalise_path(self.path, fallback=cleaned_name))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "path": list(self.path or ()),
+            "description": self.description,
+            "required": self.required,
+            "multiple": self.multiple,
+        }
+
+
+@dataclass(frozen=True)
+class DocumentCollection:
+    """Describe a repeated structure such as invoice lines."""
+
+    name: str
+    path: Sequence[str] | None = None
+    fields: Sequence[DocumentField] = field(default_factory=tuple)
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        cleaned_name = str(self.name or "").strip()
+        if not cleaned_name:
+            raise ValueError("Collection names must be non empty")
+        object.__setattr__(self, "name", cleaned_name)
+        object.__setattr__(self, "path", _normalise_path(self.path, fallback=cleaned_name))
+
+        labels = [field.label for field in self.fields]
+        duplicates = {label for label in labels if labels.count(label) > 1}
+        if duplicates:
+            raise ValueError(f"Duplicate labels in collection '{self.name}': {sorted(duplicates)}")
+
+    def label_map(self) -> dict[str, DocumentField]:
+        return {field.label: field for field in self.fields}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "path": list(self.path or ()),
+            "description": self.description,
+            "fields": [field.to_dict() for field in self.fields],
+        }
+
+
+@dataclass
+class DocumentSchema:
+    """Container describing how to project entities into JSON."""
+
+    fields: Sequence[DocumentField] = field(default_factory=tuple)
+    collections: Sequence[DocumentCollection] = field(default_factory=tuple)
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        simple_labels = [field.label for field in self.fields]
+        duplicates = {label for label in simple_labels if simple_labels.count(label) > 1}
+        if duplicates:
+            raise ValueError(f"Duplicate labels for fields: {sorted(duplicates)}")
+
+        collection_labels = []
+        for collection in self.collections:
+            collection_labels.extend(field.label for field in collection.fields)
+
+        conflicts = set(simple_labels) & set(collection_labels)
+        if conflicts:
+            raise ValueError(f"Labels must be unique across schema: {sorted(conflicts)}")
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, Any] | None) -> "DocumentSchema":
+        if not mapping:
+            return cls()
+
+        field_specs = mapping.get("fields", []) if isinstance(mapping, Mapping) else []
+        fields: list[DocumentField] = []
+        for spec in field_specs:
+            if not isinstance(spec, Mapping):
+                continue
+            fields.append(
+                DocumentField(
+                    name=str(spec.get("name") or spec.get("label") or "field"),
+                    label=str(spec.get("label") or spec.get("name") or "field"),
+                    path=spec.get("path"),
+                    description=str(spec.get("description", "")),
+                    required=bool(spec.get("required", False)),
+                    multiple=bool(spec.get("multiple", False)),
+                )
+            )
+
+        collections_specs = mapping.get("collections", []) if isinstance(mapping, Mapping) else []
+        collections: list[DocumentCollection] = []
+        for collection_spec in collections_specs:
+            if not isinstance(collection_spec, Mapping):
+                continue
+            name = str(collection_spec.get("name") or "collection")
+            field_defs = []
+            for field_spec in collection_spec.get("fields", []):
+                if not isinstance(field_spec, Mapping):
+                    continue
+                field_defs.append(
+                    DocumentField(
+                        name=str(field_spec.get("name") or field_spec.get("label") or "field"),
+                        label=str(field_spec.get("label") or field_spec.get("name") or "field"),
+                        path=field_spec.get("path"),
+                        description=str(field_spec.get("description", "")),
+                        required=bool(field_spec.get("required", False)),
+                    )
+                )
+            collections.append(
+                DocumentCollection(
+                    name=name,
+                    path=collection_spec.get("path"),
+                    description=str(collection_spec.get("description", "")),
+                    fields=tuple(field_defs),
+                )
+            )
+
+        metadata = mapping.get("metadata") if isinstance(mapping, Mapping) else None
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        return cls(fields=tuple(fields), collections=tuple(collections), metadata=dict(metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fields": [field.to_dict() for field in self.fields],
+            "collections": [collection.to_dict() for collection in self.collections],
+            "metadata": dict(self.metadata),
+        }
+
+    def entity_labels(self) -> list[str]:
+        labels = [field.label for field in self.fields]
+        for collection in self.collections:
+            labels.extend(field.label for field in collection.fields)
+        return sorted(set(labels))
+
+    def label_names(self) -> list[str]:
+        labels = []
+        for label in self.entity_labels():
+            labels.append(f"B-{label}")
+            labels.append(f"I-{label}")
+        return labels
+
+    def empty(self) -> dict[str, Any]:
+        structure: dict[str, Any] = {}
+        for field in self.fields:
+            container, key = self._ensure_container(structure, field.path)
+            container[key] = [] if field.multiple else _empty_payload()
+        for collection in self.collections:
+            container, key = self._ensure_container(structure, collection.path)
+            container[key] = []
+        return structure
+
+    def _ensure_container(
+        self, structure: MutableMapping[str, Any], path: Sequence[str]
+    ) -> tuple[MutableMapping[str, Any], str]:
+        current = structure
+        for segment in path[:-1]:
+            if segment not in current or not isinstance(current[segment], MutableMapping):
+                current[segment] = {}
+            current = current[segment]
+        return current, path[-1]
+
+    def _build_payload(
+        self,
+        *,
+        value: str,
+        score: float,
+        start: Optional[int],
+        end: Optional[int],
+        label: str,
+        agent: Optional[str],
+        metadata: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        provenance: dict[str, Any] = {"label": label}
+        if agent:
+            provenance["agent"] = agent
+        if start is not None:
+            provenance["start"] = start
+        if end is not None:
+            provenance["end"] = end
+        if metadata:
+            provenance["metadata"] = dict(metadata)
+        payload = {"value": value, "confidence": float(score), "provenance": provenance or None}
+        return payload
+
+    def map_predictions(
+        self,
+        predictions: Iterable[Mapping[str, Any]],
+        *,
+        threshold: float = 0.5,
+        agent: Optional[str] = None,
+        text: Optional[str] = None,
+    ) -> dict[str, Any]:
+        structure = self.empty()
+        simple_fields = {field.label: field for field in self.fields}
+        collection_field_map: dict[str, tuple[DocumentCollection, DocumentField]] = {}
+        for collection in self.collections:
+            for field in collection.fields:
+                collection_field_map[field.label] = (collection, field)
+
+        collection_rows: dict[str, list[dict[str, Any]]] = {collection.name: [] for collection in self.collections}
+
+        normalised_predictions = []
+        for raw in predictions:
+            if not isinstance(raw, Mapping):
+                continue
+            label = raw.get("label") or raw.get("entity") or raw.get("type")
+            if not label:
+                continue
+            try:
+                cleaned_label = _normalise_label(label)
+            except ValueError:
+                continue
+            text_value = str(raw.get("text") or raw.get("value") or "").strip()
+            start = raw.get("start")
+            end = raw.get("end")
+            try:
+                start_int = int(start) if start is not None else None
+            except (TypeError, ValueError):
+                start_int = None
+            try:
+                end_int = int(end) if end is not None else None
+            except (TypeError, ValueError):
+                end_int = None
+            score = raw.get("confidence")
+            if score is None:
+                score = raw.get("score")
+            try:
+                score_value = float(score)
+            except (TypeError, ValueError):
+                score_value = 0.0
+            metadata = raw.get("metadata") or raw.get("provenance") or {}
+            if not isinstance(metadata, Mapping):
+                metadata = {}
+            metadata = dict(metadata)
+            for key in ("group", "row", "index"):
+                if key not in metadata and key in raw:
+                    metadata[key] = raw[key]
+            normalised_predictions.append(
+                {
+                    "label": cleaned_label,
+                    "text": text_value,
+                    "start": start_int,
+                    "end": end_int,
+                    "score": score_value,
+                    "metadata": metadata,
+                }
+            )
+
+        def _sort_key(item: Mapping[str, Any]) -> tuple[float, float]:
+            start_pos = item.get("start")
+            if start_pos is None:
+                start_value = math.inf
+            else:
+                start_value = float(start_pos)
+            return (start_value, -float(item.get("score") or 0.0))
+
+        normalised_predictions.sort(key=_sort_key)
+
+        for prediction in normalised_predictions:
+            score_value = float(prediction.get("score") or 0.0)
+            if score_value < threshold:
+                continue
+            label = prediction["label"]
+            payload = self._build_payload(
+                value=prediction.get("text", ""),
+                score=score_value,
+                start=prediction.get("start"),
+                end=prediction.get("end"),
+                label=label,
+                agent=agent,
+                metadata=prediction.get("metadata"),
+            )
+
+            if label in simple_fields:
+                field = simple_fields[label]
+                container, key = self._ensure_container(structure, field.path)
+                if field.multiple:
+                    container.setdefault(key, [])
+                    container[key].append(payload)
+                else:
+                    current_payload = container.get(key)
+                    current_confidence = (
+                        float(current_payload.get("confidence", 0.0))
+                        if isinstance(current_payload, Mapping)
+                        else 0.0
+                    )
+                    if score_value >= current_confidence:
+                        container[key] = payload
+                continue
+
+            if label not in collection_field_map:
+                continue
+
+            collection, field = collection_field_map[label]
+            rows = collection_rows[collection.name]
+
+            metadata = prediction.get("metadata") or {}
+            row_identifier = metadata.get("group")
+            if row_identifier is None:
+                row_identifier = metadata.get("row")
+
+            target_row: Optional[dict[str, Any]] = None
+            if row_identifier is not None:
+                for row in rows:
+                    if row.get("_row_id") == row_identifier:
+                        target_row = row
+                        break
+                if target_row is None:
+                    target_row = {"_row_id": row_identifier}
+                    rows.append(target_row)
+            else:
+                for row in rows:
+                    if field.name not in row:
+                        target_row = row
+                        break
+                if target_row is None:
+                    target_row = {}
+                    rows.append(target_row)
+
+            provenance = payload.get("provenance") or {}
+            start_position = provenance.get("start")
+            if start_position is not None:
+                anchor = target_row.get("_anchor")
+                if anchor is None or start_position < anchor:
+                    target_row["_anchor"] = start_position
+
+            target_row[field.name] = payload
+
+        for collection in self.collections:
+            container, key = self._ensure_container(structure, collection.path)
+            rows = collection_rows.get(collection.name, [])
+            rows.sort(key=lambda row: (row.get("_row_id"), row.get("_anchor", math.inf)))
+            normalised_rows: list[dict[str, Any]] = []
+            for row in rows:
+                row_payload: dict[str, Any] = {}
+                confidences = []
+                for field in collection.fields:
+                    payload = row.get(field.name, _empty_payload())
+                    row_payload[field.name] = payload
+                    confidence = float(payload.get("confidence") or 0.0)
+                    if confidence:
+                        confidences.append(confidence)
+                row_payload["_confidence"] = mean(confidences) if confidences else 0.0
+                if "_row_id" in row:
+                    row_payload["_row_id"] = row["_row_id"]
+                normalised_rows.append(row_payload)
+            container[key] = normalised_rows
+
+        return structure
+
+
+class DocumentVocabulary:
+    """Build a document oriented vocabulary to extend base tokenizers."""
+
+    DEFAULT_TERMS = [
+        "facture",
+        "adresse",
+        "total",
+        "montant",
+        "quantité",
+        "prix",
+        "unitaire",
+        "tva",
+        "siren",
+        "siret",
+        "iban",
+        "bic",
+        "banque",
+        "client",
+        "fournisseur",
+        "paiement",
+        "échéance",
+        "date",
+        "numéro",
+        "ligne",
+        "description",
+        "code",
+        "postal",
+        "ville",
+        "pays",
+    ]
+
+    TOKEN_PATTERN = re.compile(r"[\w\-']+", re.UNICODE)
+
+    def __init__(
+        self,
+        tokens: Sequence[str],
+        *,
+        frequencies: Mapping[str, int] | None = None,
+        domain_terms: Iterable[str] | None = None,
+    ) -> None:
+        self.tokens = list(_deduplicate_preserve_order(tokens))
+        if frequencies is None:
+            frequencies = {}
+        self.frequencies = {str(k): int(v) for k, v in frequencies.items()}
+        if domain_terms is None:
+            domain_terms = []
+        self.domain_terms = _deduplicate_preserve_order([str(term) for term in domain_terms])
+
+    @classmethod
+    def from_examples(
+        cls,
+        examples: Iterable[Mapping[str, Any]],
+        *,
+        additional_terms: Iterable[str] | None = None,
+        max_terms: int = 200,
+    ) -> "DocumentVocabulary":
+        from collections import Counter
+
+        counter: Counter[str] = Counter()
+        for example in examples:
+            data = example.get("data") if isinstance(example, Mapping) else None
+            text = ""
+            if isinstance(data, Mapping):
+                text = str(data.get("text") or "")
+            for match in cls.TOKEN_PATTERN.finditer(text.lower()):
+                token = match.group(0)
+                if len(token) <= 1:
+                    continue
+                counter[token] += 1
+
+        most_common = counter.most_common(max_terms)
+        inferred_tokens = [token for token, _ in most_common]
+        frequencies = {token: freq for token, freq in most_common}
+
+        tokens: list[str] = list(cls.DEFAULT_TERMS)
+        tokens.extend(inferred_tokens)
+
+        extra_terms = list(additional_terms or [])
+        tokens.extend(extra_terms)
+
+        return cls(tokens, frequencies=frequencies, domain_terms=extra_terms)
+
+    def apply_to_tokenizer(self, tokenizer: Any) -> int:
+        if hasattr(tokenizer, "add_tokens"):
+            try:
+                return int(tokenizer.add_tokens(self.tokens))
+            except Exception:
+                return 0
+        return 0
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "size": len(self.tokens),
+            "tokens": list(self.tokens),
+            "frequencies": dict(self.frequencies),
+            "domain_terms": list(self.domain_terms),
+        }
+
+
+@dataclass
+class DocumentExtractionAgent:
+    """Light-weight representation of a specialised extraction agent."""
+
+    name: str
+    schema: DocumentSchema
+    threshold: float = 0.5
+    vocabulary: Optional[DocumentVocabulary] = None
+    description: str = ""
+
+    def map_predictions(
+        self,
+        predictions: Iterable[Mapping[str, Any]],
+        *,
+        text: Optional[str] = None,
+    ) -> dict[str, Any]:
+        return self.schema.map_predictions(
+            predictions,
+            threshold=self.threshold,
+            agent=self.name,
+            text=text,
+        )
+
+    def empty_output(self) -> dict[str, Any]:
+        return self.schema.empty()
+
+    def to_descriptor(self, *, base_model: Optional[str] = None) -> dict[str, Any]:
+        payload = {
+            "name": self.name,
+            "threshold": float(self.threshold),
+            "schema": self.schema.to_dict(),
+        }
+        if self.vocabulary is not None:
+            payload["vocabulary"] = self.vocabulary.to_metadata()
+        if self.description:
+            payload["description"] = self.description
+        if base_model:
+            payload["base_model"] = base_model
+        return payload
+
+    def label_names(self) -> list[str]:
+        return ["O", *self.schema.label_names()]
+
+
+class CompositeAgent:
+    """Combine the outputs of multiple specialised agents."""
+
+    def __init__(self, agents: Sequence[DocumentExtractionAgent]):
+        self._agents = list(agents)
+
+    def combine(self, predictions: Mapping[str, Iterable[Mapping[str, Any]]]) -> dict[str, Any]:
+        combined: dict[str, Any] = {}
+        for agent in self._agents:
+            agent_predictions = predictions.get(agent.name, [])
+            result = agent.map_predictions(agent_predictions)
+            combined = self._merge(combined, result)
+        return combined
+
+    def _merge(self, base: dict[str, Any], new: Mapping[str, Any]) -> dict[str, Any]:
+        merged = copy.deepcopy(base)
+        for key, value in new.items():
+            if key not in merged:
+                merged[key] = copy.deepcopy(value)
+                continue
+            existing = merged[key]
+            if _is_payload(value):
+                if not _is_payload(existing) or float(existing.get("confidence", 0.0)) < float(
+                    value.get("confidence", 0.0)
+                ):
+                    merged[key] = copy.deepcopy(value)
+                continue
+            if isinstance(value, list):
+                if not isinstance(existing, list):
+                    merged[key] = list(value)
+                else:
+                    merged[key].extend(copy.deepcopy(value))
+                continue
+            if isinstance(value, Mapping):
+                if not isinstance(existing, Mapping):
+                    merged[key] = copy.deepcopy(value)
+                else:
+                    merged[key] = self._merge(dict(existing), value)
+                continue
+            merged[key] = copy.deepcopy(value)
+        return merged
+
+
+def save_descriptor(path: Any, descriptor: Mapping[str, Any]) -> None:
+    target = Path(path)
+    target.write_text(json.dumps(descriptor, indent=2, ensure_ascii=False), encoding="utf-8")
+

--- a/src/helpers/trainer.py
+++ b/src/helpers/trainer.py
@@ -29,7 +29,13 @@ from transformers import (
     TrainingArguments,
 )
 
-from src.helpers.callbacks import MongoTrainLogger
+from .callbacks import MongoTrainLogger
+from .document import (
+    DocumentExtractionAgent,
+    DocumentSchema,
+    DocumentVocabulary,
+    save_descriptor,
+)
 
 try:  # pragma: no cover - optional dependency
     from peft import LoraConfig, TaskType, get_peft_model
@@ -210,6 +216,9 @@ def prepare_dataset(
     examples: Sequence[Mapping[str, Any]],
     label_names: Sequence[str],
     tokenizer: CamembertTokenizerFast,
+    *,
+    schema: Optional[DocumentSchema] = None,
+    vocabulary: Optional[DocumentVocabulary] = None,
 ) -> Tuple[Dataset, Dict[str, int], Dict[int, str], Dict[str, Any]]:
     label_names = _normalise_labels(label_names)
     label2id = {name: i for i, name in enumerate(label_names)}
@@ -288,6 +297,8 @@ def prepare_dataset(
         "texts": [example.text for example in cleaned_examples],
         "cleaning_stats": dict(stats),
         "schema": {"text": "str", "entities": "List[Tuple[int, int, str]]"},
+        "document_schema": schema.to_dict() if schema else None,
+        "document_vocabulary": vocabulary.to_metadata() if vocabulary else None,
     }
     return dataset, label2id, id2label, metadata
 
@@ -354,12 +365,47 @@ def trainer(
         raise ValueError("Dataset vide: aucune donnée à entraîner")
 
     parameters = parameters or {}
-    label_names = model.get("labels") or []
+    mapper_spec = model.get("mapper")
+    schema = DocumentSchema.from_mapping(mapper_spec)
+
+    raw_label_names = list(model.get("labels") or [])
+    if not raw_label_names and schema.entity_labels():
+        generated = []
+        for label in schema.entity_labels():
+            generated.append(f"B-{label}")
+            generated.append(f"I-{label}")
+        raw_label_names = [O_LABEL, *generated]
+
+    label_names = _normalise_labels(raw_label_names)
+    if len(label_names) <= 1:
+        raise ValueError("Aucune étiquette valide n'a été fournie pour l'entraînement")
+
     model_reference = model.get("reference", "model")
     resolved_version = version or model.get("version", "1.0")
 
-    tokenizer = CamembertTokenizerFast.from_pretrained(MODEL_NAME)
-    train_ds, label2id, id2label, metadata = prepare_dataset(dataset, label_names, tokenizer)
+    base_model_name = str(model.get("base_model") or MODEL_NAME)
+    tokenizer = CamembertTokenizerFast.from_pretrained(base_model_name)
+
+    additional_terms = model.get("vocabulary") or []
+    vocabulary = DocumentVocabulary.from_examples(dataset, additional_terms=additional_terms)
+    added_tokens = vocabulary.apply_to_tokenizer(tokenizer)
+    if added_tokens:
+        LOGGER.info("Vocabulaire documentaire: %s jetons ajoutés", added_tokens)
+
+    if schema.fields or schema.collections:
+        LOGGER.info(
+            "Schéma documentaire chargé: %s champs, %s collections",
+            len(schema.fields),
+            len(schema.collections),
+        )
+
+    train_ds, label2id, id2label, metadata = prepare_dataset(
+        dataset,
+        label_names,
+        tokenizer,
+        schema=schema,
+        vocabulary=vocabulary,
+    )
 
     LOGGER.info(
         "Schéma dataset: %s", metadata.get("schema", {"text": "str", "entities": "list"})
@@ -394,7 +440,7 @@ def trainer(
         parameters=parameters.get("continued_pretraining"),
     )
 
-    base_model_path = domain_pretraining_path or MODEL_NAME
+    base_model_path = domain_pretraining_path or base_model_name
 
     ner_model = CamembertForTokenClassification.from_pretrained(
         base_model_path,
@@ -492,6 +538,7 @@ def trainer(
     trainer_instance.save_model(str(output_dir))
     tokenizer.save_pretrained(str(output_dir))
 
+    threshold: Optional[float] = None
     if eval_dataset is not None:
         threshold = calibrate_probability_threshold(
             trainer_instance,
@@ -517,6 +564,31 @@ def trainer(
         parameters.get("active_learning"),
         output_dir=output_dir,
     )
+
+    thresholds_config = parameters.get("thresholds") if isinstance(parameters, Mapping) else None
+    if threshold is None:
+        if isinstance(thresholds_config, Mapping) and thresholds_config.get("default") is not None:
+            threshold = _ensure_float(thresholds_config.get("default"), 0.5)
+        else:
+            threshold = _ensure_float(parameters.get("default_threshold"), 0.5)
+
+    descriptor: Optional[dict[str, Any]] = None
+    if schema.fields or schema.collections:
+        descriptor = DocumentExtractionAgent(
+            name=model.get("name", model_reference),
+            schema=schema,
+            threshold=threshold,
+            vocabulary=vocabulary,
+            description=str(model.get("description", "")),
+        ).to_descriptor(base_model=str(base_model_path))
+        save_descriptor(output_dir / "agent.json", descriptor)
+        save_descriptor(output_dir / "schema.json", schema.to_dict())
+
+    if vocabulary is not None:
+        save_descriptor(output_dir / "vocabulary.json", vocabulary.to_metadata())
+
+    if descriptor is not None:
+        LOGGER.info("Descripteur d'agent enregistré dans %s", output_dir / "agent.json")
 
     if callback is not None:
         callback.close()

--- a/src/tasks/trainer.py
+++ b/src/tasks/trainer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -81,21 +82,36 @@ def run_task(*, doc: Optional[Mapping[str, Any]] = None, db=None, MAX_WORKERS: i
 
         target_path = Path("sardine.agents") / doc.get("reference", "agent") / version
 
-        agents.insert_one(
-            {
-                "created_by": doc.get("created_by"),
-                "created_at": datetime.utcnow(),
-                "model": model_id,
-                "version": version,
-                "name": doc.get("name"),
-                "reference": doc.get("reference"),
-                "description": doc.get("description"),
-                "path": str(target_path),
-                "mapper": model.get("mapper"),
-                "requirements": doc.get("requirements", []),
-                "status": "enabled",
-            }
-        )
+        descriptor_data: dict[str, Any] = {}
+        descriptor_path = target_path / "agent.json"
+        if descriptor_path.exists():
+            try:
+                descriptor_data = json.loads(descriptor_path.read_text(encoding="utf-8"))
+            except Exception as error:  # pragma: no cover - defensive logging
+                LOGGER.warning("Impossible de lire le descripteur d'agent: %s", error)
+                descriptor_data = {}
+
+        payload = {
+            "created_by": doc.get("created_by"),
+            "created_at": datetime.utcnow(),
+            "model": model_id,
+            "version": version,
+            "name": doc.get("name"),
+            "reference": doc.get("reference"),
+            "description": doc.get("description"),
+            "path": str(target_path),
+            "mapper": descriptor_data.get("schema") or model.get("mapper"),
+            "requirements": doc.get("requirements", []),
+            "status": "enabled",
+        }
+        if "threshold" in descriptor_data:
+            payload["confidence_threshold"] = descriptor_data.get("threshold")
+        if "vocabulary" in descriptor_data:
+            payload["vocabulary"] = descriptor_data.get("vocabulary")
+        if "base_model" in descriptor_data:
+            payload["base_model"] = descriptor_data.get("base_model")
+
+        agents.insert_one(payload)
 
         cleanup_checkpoints(target_path)
         LOGGER.info("[%s] entraînement terminé", job_id)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -196,11 +196,20 @@ sys.modules.setdefault(
     ),
 )
 
+from helpers.document import (
+    CompositeAgent,
+    DocumentExtractionAgent,
+    DocumentSchema,
+    DocumentVocabulary,
+)
 from helpers.trainer import O_LABEL, prepare_dataset
 
 
 class DummyTokenizer:
     """Tokenizer stub returning deterministic per-character offsets."""
+
+    def __init__(self) -> None:
+        self.added_tokens: list[str] = []
 
     def __call__(
         self,
@@ -235,6 +244,13 @@ class DummyTokenizer:
             "offset_mapping": offsets,
             "attention_mask": attention_mask,
         }
+
+    def add_tokens(self, tokens) -> int:  # pragma: no cover - simple stub
+        token_list = list(tokens)
+        if not token_list:
+            return 0
+        self.added_tokens.extend(token_list)
+        return len(token_list)
 
 
 class PrepareDatasetOverlapTests(unittest.TestCase):
@@ -283,6 +299,137 @@ class PrepareDatasetOverlapTests(unittest.TestCase):
         child_label_id = label2id["B-CHILD"]
         flattened = list(prepared[0]["labels"])
         self.assertIn(child_label_id, flattened)
+
+
+class DocumentSchemaMappingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        schema_mapping = {
+            "fields": [
+                {
+                    "name": "invoice_number",
+                    "label": "INVOICE_NUMBER",
+                    "path": ["invoice", "number"],
+                },
+                {
+                    "name": "customer_name",
+                    "label": "CUSTOMER_NAME",
+                    "path": ["customer", "name"],
+                },
+            ],
+            "collections": [
+                {
+                    "name": "lines",
+                    "path": ["invoice", "lines"],
+                    "fields": [
+                        {"name": "description", "label": "LINE_DESCRIPTION", "path": ["description"]},
+                        {"name": "quantity", "label": "LINE_QUANTITY", "path": ["quantity"]},
+                    ],
+                }
+            ],
+        }
+        self.schema = DocumentSchema.from_mapping(schema_mapping)
+        self.agent = DocumentExtractionAgent(name="invoice", schema=self.schema, threshold=0.5)
+
+    def test_schema_maps_predictions_to_json_structure(self) -> None:
+        predictions = [
+            {"label": "INVOICE_NUMBER", "text": "F2024-001", "score": 0.92, "start": 0, "end": 9},
+            {"label": "CUSTOMER_NAME", "text": "ACME", "score": 0.9, "start": 10, "end": 14},
+            {"label": "LINE_DESCRIPTION", "text": "Service A", "score": 0.85, "start": 20, "end": 29, "group": 0},
+            {"label": "LINE_QUANTITY", "text": "2", "score": 0.8, "start": 30, "end": 31, "group": 0},
+            {"label": "LINE_DESCRIPTION", "text": "Service B", "score": 0.88, "start": 40, "end": 49, "group": 1},
+        ]
+
+        result = self.agent.map_predictions(predictions)
+
+        self.assertEqual(result["invoice"]["number"]["value"], "F2024-001")
+        self.assertGreater(result["invoice"]["number"]["confidence"], 0.9)
+        self.assertEqual(result["customer"]["name"]["value"], "ACME")
+
+        lines = result["invoice"]["lines"]
+        self.assertEqual(len(lines), 2)
+        first_line = lines[0]
+        self.assertEqual(first_line["description"]["value"], "Service A")
+        self.assertEqual(first_line["quantity"]["value"], "2")
+        self.assertAlmostEqual(first_line["_confidence"], (0.85 + 0.8) / 2, places=4)
+        self.assertEqual(first_line["_row_id"], 0)
+        self.assertEqual(first_line["description"]["provenance"]["metadata"]["group"], 0)
+
+        second_line = lines[1]
+        self.assertEqual(second_line["description"]["value"], "Service B")
+        self.assertIsNone(second_line["quantity"]["value"])
+        self.assertAlmostEqual(second_line["_confidence"], 0.88, places=4)
+
+
+class DocumentVocabularyTests(unittest.TestCase):
+    def test_vocabulary_includes_domain_terms_and_applies_to_tokenizer(self) -> None:
+        examples = [
+            {"data": {"text": "Facture adressée à Mme Dupont 75001 Paris"}},
+            {"data": {"text": "Total facture 1200 EUR payé par virement bancaire"}},
+        ]
+        vocabulary = DocumentVocabulary.from_examples(examples, additional_terms=["référence"])
+        metadata = vocabulary.to_metadata()
+
+        self.assertIn("facture", metadata["tokens"])
+        self.assertIn("référence", metadata["tokens"])
+        self.assertGreaterEqual(metadata["size"], len(DocumentVocabulary.DEFAULT_TERMS))
+
+        tokenizer = DummyTokenizer()
+        added = vocabulary.apply_to_tokenizer(tokenizer)
+        self.assertEqual(added, len(vocabulary.tokens))
+        self.assertEqual(tokenizer.added_tokens, vocabulary.tokens)
+
+
+class CompositeAgentTests(unittest.TestCase):
+    def setUp(self) -> None:
+        address_schema = DocumentSchema.from_mapping(
+            {
+                "fields": [
+                    {
+                        "name": "company_address",
+                        "label": "ADDRESS",
+                        "path": ["company", "address"],
+                    }
+                ]
+            }
+        )
+        lines_schema = DocumentSchema.from_mapping(
+            {
+                "collections": [
+                    {
+                        "name": "lines",
+                        "path": ["invoice", "lines"],
+                        "fields": [
+                            {"name": "description", "label": "LINE_DESCRIPTION", "path": ["description"]},
+                            {"name": "quantity", "label": "LINE_QUANTITY", "path": ["quantity"]},
+                        ],
+                    }
+                ]
+            }
+        )
+        self.address_agent = DocumentExtractionAgent(name="adresse", schema=address_schema, threshold=0.4)
+        self.lines_agent = DocumentExtractionAgent(name="lignes", schema=lines_schema, threshold=0.4)
+        self.composite = CompositeAgent([self.address_agent, self.lines_agent])
+
+    def test_composite_merges_outputs_using_best_confidence(self) -> None:
+        predictions = {
+            "adresse": [
+                {"label": "ADDRESS", "text": "12 rue Bleue", "score": 0.6, "start": 0, "end": 12},
+                {"label": "ADDRESS", "text": "14 rue Verte", "score": 0.95, "start": 0, "end": 12},
+            ],
+            "lignes": [
+                {"label": "LINE_DESCRIPTION", "text": "Produit A", "score": 0.7, "start": 20, "end": 29, "group": 0},
+                {"label": "LINE_QUANTITY", "text": "5", "score": 0.65, "start": 30, "end": 31, "group": 0},
+            ],
+        }
+
+        result = self.composite.combine(predictions)
+
+        self.assertEqual(result["company"]["address"]["value"], "14 rue Verte")
+        lines = result["invoice"]["lines"]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]["description"]["value"], "Produit A")
+        self.assertEqual(lines[0]["quantity"]["value"], "5")
+        self.assertAlmostEqual(lines[0]["_confidence"], (0.7 + 0.65) / 2, places=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a document helper module that models document schemas, composite agents and vocabularies, and can serialise descriptors
- refactor the training pipeline to consume the document schema, extend the tokenizer with a domain vocabulary, and persist the trained agent metadata
- capture the generated descriptor when registering agents and extend the unit test suite to cover the new document helpers

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a1b41164832ab0bda3d494fa7152